### PR TITLE
replace pushd popd on rust-xtensa instructions for Ubuntu 20

### DIFF
--- a/docs/rust-on-xtensa-installation-x86_64-unknown-linux-gnu-bionic.md
+++ b/docs/rust-on-xtensa-installation-x86_64-unknown-linux-gnu-bionic.md
@@ -17,15 +17,15 @@ mkdir -p ~/.rustup/toolchains/xtensa
 
 wget https://dl.espressif.com/dl/idf-rust/dist/x86_64-unknown-linux-gnu/bionic/rust-1.50.0-dev-x86_64-unknown-linux-gnu-bionic.tar.xz
 tar xvf rust-1.50.0-dev-x86_64-unknown-linux-gnu-bionic.tar.xz
-pushd rust-1.50.0-dev-x86_64-unknown-linux-gnu
+cd rust-1.50.0-dev-x86_64-unknown-linux-gnu
 ./install.sh --destdir=~/.rustup/toolchains/xtensa --prefix="" --without=rust-docs
-popd
+cd ..
 
 wget https://dl.espressif.com/dl/idf-rust/dist/x86_64-unknown-linux-gnu/rust-src-1.50.0-dev.tar.xz
 tar xvf rust-src-1.50.0-dev.tar.xz
-pushd rust-src-1.50.0-dev
+cd rust-src-1.50.0-dev
 ./install.sh --destdir=~/.rustup/toolchains/xtensa --prefix="" --without=rust-docs
-popd
+cd ..
 
 rustup default xtensa
 

--- a/docs/rust-on-xtensa-installation-x86_64-unknown-linux-gnu.md
+++ b/docs/rust-on-xtensa-installation-x86_64-unknown-linux-gnu.md
@@ -19,15 +19,15 @@ mkdir -p ~/.rustup/toolchains/xtensa
 
 wget https://dl.espressif.com/dl/idf-rust/dist/x86_64-unknown-linux-gnu/rust-1.50.0-dev-x86_64-unknown-linux-gnu.tar.xz
 tar xvf rust-1.50.0-dev-x86_64-unknown-linux-gnu.tar.xz
-pushd rust-1.50.0-dev-x86_64-unknown-linux-gnu
+cd rust-1.50.0-dev-x86_64-unknown-linux-gnu
 ./install.sh --destdir=~/.rustup/toolchains/xtensa --prefix="" --without=rust-docs
-popd
+cd ..
 
 wget https://dl.espressif.com/dl/idf-rust/dist/x86_64-unknown-linux-gnu/rust-src-1.50.0-dev.tar.xz
 tar xvf rust-src-1.50.0-dev.tar.xz
-pushd rust-src-1.50.0-dev
+cd rust-src-1.50.0-dev
 ./install.sh --destdir=~/.rustup/toolchains/xtensa --prefix="" --without=rust-docs
-popd
+cd ..
 
 rustup default xtensa
 


### PR DESCRIPTION
**Related Issue** : https://github.com/espressif/rust-esp32-example/issues/16
**Definition of done** : 
- [x] : Replace `pushd` and `popd` 
- [x] : Test on Ubuntu 20.04

**Description** 
Replaced to `cd somedir` and `cd ..`