### PR TITLE
docker: split images to idf-rust and idf-rust-examples

### DIFF
--- a/.github/workflows/publish-idf-rust-examples-image.yml
+++ b/.github/workflows/publish-idf-rust-examples-image.yml
@@ -1,4 +1,4 @@
-name: Publish esp-idf-rust image on DockerHub
+name: Publish idf-rust image on DockerHub
 
 on: workflow_dispatch
 
@@ -19,4 +19,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: espressif/idf-rust:latest
+          tags: espressif/idf-rust-examples:latest

--- a/.github/workflows/publish-idf-rust-image.yml
+++ b/.github/workflows/publish-idf-rust-image.yml
@@ -1,0 +1,22 @@
+name: Publish idf-rust image on DockerHub
+
+on: workflow_dispatch
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          context: support/idf-rust
+          push: true
+          tags: espressif/idf-rust:latest

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ target/
 Cargo.lock
 **/*.rs.bk
 *.pdb
+.idea/
+cmake-build-debug/

--- a/support/idf-rust-examples/entrypoint.sh
+++ b/support/idf-rust-examples/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+. $IDF_PATH/export.sh
+cat /etc/motd
+
+exec "$@"

--- a/support/idf-rust-examples/motd
+++ b/support/idf-rust-examples/motd
@@ -1,0 +1,19 @@
+==============================================================================
+=           Docker image with ESP-IDF, Rust compiler and examples            =
+=              https://github.com/espressif/rust-esp32-example               =
+==============================================================================
+
+Available examples:
+
+* "idf.py-first" approach - integration via CMake files
+  ```sh
+    cd /opt/rust-esp32-example
+    idf.py build
+  ```
+
+* "cargo-first" approach
+  ```sh
+    cd /opt/rust-esp32-std-hello
+    cargo build --release
+  ```
+

--- a/support/idf-rust/Dockerfile
+++ b/support/idf-rust/Dockerfile
@@ -14,7 +14,8 @@ ARG TOOLCHAIN_DESTINATION_DIR="/opt/esp"
 RUN curl https://sh.rustup.rs -sSf | bash -s -- --profile minimal --default-toolchain nightly  -y
 WORKDIR /opt
 
-RUN wget -q https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/${RUST_DIST}.tar.xz \
+#RUN wget -q https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/${RUST_DIST}.tar.xz \
+RUN wget -q https://github.com/georgik/idf-rust-build/releases/download/v${VERSION}/${RUST_DIST}.tar.xz \
     && tar xvf ${RUST_DIST}.tar.xz \
     && ./${RUST_DIST}/install.sh --destdir=${TOOLCHAIN_DESTINATION_DIR} --prefix="" --without=rust-docs \
     && rm -rf ${RUST_DIST} ${RUST_DIST}.tar.xz

--- a/support/idf-rust/Dockerfile
+++ b/support/idf-rust/Dockerfile
@@ -1,0 +1,32 @@
+FROM espressif/idf
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ENV RUSTUP_HOME=/opt/rust
+ENV CARGO_HOME=/opt/cargo
+ENV PATH=/opt/cargo/bin:/opt/rust/bin:/opt/xtensa-esp32-elf-clang/bin:$PATH
+
+ARG VERSION="1.54.0-dev"
+ARG ARCH="x86_64-unknown-linux-gnu"
+ARG RUST_DIST="rust-${VERSION}-${ARCH}"
+ARG RUST_SRC_DIST="rust-src-${VERSION}"
+ARG TOOLCHAIN_DESTINATION_DIR="/opt/esp"
+
+RUN curl https://sh.rustup.rs -sSf | bash -s -- --profile minimal --default-toolchain nightly  -y
+WORKDIR /opt
+
+RUN wget -q https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/${RUST_DIST}.tar.xz \
+    && tar xvf ${RUST_DIST}.tar.xz \
+    && ./${RUST_DIST}/install.sh --destdir=${TOOLCHAIN_DESTINATION_DIR} --prefix="" --without=rust-docs \
+    && rm -rf ${RUST_DIST} ${RUST_DIST}.tar.xz
+
+RUN wget -q https://dl.espressif.com/dl/idf-rust/dist/noarch/${RUST_SRC_DIST}.tar.xz \
+    && tar xvf ${RUST_SRC_DIST}.tar.xz \
+    && ./${RUST_SRC_DIST}/install.sh --destdir=${TOOLCHAIN_DESTINATION_DIR} --prefix="" --without=rust-docs \
+    && rm -rf ${RUST_SRC_DIST} ${RUST_SRC_DIST}.tar.xz \
+    && rustup toolchain link esp /opt/esp \
+    && rustup default esp
+
+RUN wget -q https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/xtensa-esp32-elf-llvm11_0_0-llvmorg-11-init-21249-g36dbc8b-linux-amd64.tar.xz \
+    && tar xf xtensa-esp32-elf-llvm11_0_0-llvmorg-11-init-21249-g36dbc8b-linux-amd64.tar.xz \
+    && rm xtensa-esp32-elf-llvm11_0_0-llvmorg-11-init-21249-g36dbc8b-linux-amd64.tar.xz
+


### PR DESCRIPTION
Closes https://github.com/ivmarkov/rust-esp32-std-hello/pull/8

The idea behind this PR is to have two images:
- espressif/idf-rust - which contains Rust compiler and can be used in CI or base image for others
- espressif/idf-rust-examples - images based on idf-rust which contains additional tools and examples

Right now we have two examples:
- "idf.py-first" approach in /opt/rust-esp32-example
- "cargo-first" approach which dependes on cargo-pio in /opt/rust-esp32-std-hello - repo: https://github.com/ivmarkov/rust-esp32-std-hello.git
