### PR TITLE
Fix esp32c3 build

### DIFF
--- a/components/rustlib/CMakeLists.txt
+++ b/components/rustlib/CMakeLists.txt
@@ -9,7 +9,7 @@ idf_component_register(
 set(CARGO_BUILD_TYPE "release")
 set(CARGO_BUILD_ARG "--release")
 if(CONFIG_IDF_TARGET_ARCH_RISCV)
-    set(CARGO_TARGET "riscv32i-unknown-none-elf")
+    set(CARGO_TARGET "riscv32imc-esp-espidf")
     set(CARGO_FEATURES_ARG "")
 elseif(CONFIG_IDF_TARGET_ARCH_XTENSA)
     set(CARGO_TARGET "xtensa-esp32-espidf")

--- a/components/rustlib/build.rs
+++ b/components/rustlib/build.rs
@@ -32,7 +32,7 @@ fn run_bindgen(target: &str, out_dir: &Path) {
     let mut builder = bindgen::Builder::default();
     builder = builder.header(header);
     match target {
-        "riscv32i-unknown-none-elf" => {
+        "riscv32imc-esp-espidf" => {
             builder = builder.clang_arg("--target=riscv32");
             builder = builder.use_core();
             builder = builder.ctypes_prefix("crate::ffi");


### PR DESCRIPTION
By moving to the new upstream target, `riscv32imc-esp-espidf`.

PTAL: @georgik @JurajSadel