### PR TITLE
docs: Update LLVM installation instructions for Windows and Linux

### DIFF
--- a/docs/rust-on-xtensa-installation-x86_64-pc-windows-msvc.md
+++ b/docs/rust-on-xtensa-installation-x86_64-pc-windows-msvc.md
@@ -32,8 +32,8 @@ popd
 
 rustup default esp
 
-Invoke-WebRequest https://dl.espressif.com/dl/idf-rust/dist/${Arch}/xtensa-esp32-elf-llvm11_0_0-llvmorg-11-init-21249-g36dbc8b-win64.zip -OutFile xtensa-esp32-elf-llvm11_0_0-llvmorg-11-init-21249-g36dbc8b-win64.zip
-7z x xtensa-esp32-elf-llvm11_0_0-llvmorg-11-init-21249-g36dbc8b-win64.zip
+Invoke-WebRequest https://github.com/espressif/llvm-project/releases/download/esp-12.0.1-20210823/xtensa-esp32-elf-llvm12_0_1-esp-12.0.1-20210823-win64.zip -OutFile xtensa-esp32-elf-llvm12_0_1-esp-12.0.1-20210823-win64.zip
+7z x xtensa-esp32-elf-llvm12_0_1-esp-12.0.1-20210823-win64.zip
 $env:LIBCLANG_PATH=Join-Path -Path (Get-Location) -ChildPath xtensa-esp32-elf-clang\bin
 $env:PATH+=";$env:LIBCLANG_PATH"
 

--- a/docs/rust-on-xtensa-installation-x86_64-unknown-linux-gnu.md
+++ b/docs/rust-on-xtensa-installation-x86_64-unknown-linux-gnu.md
@@ -35,8 +35,8 @@ tar xvf ${RUST_SRC_DIST}.tar.xz
 
 rustup default esp
 
-wget https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/xtensa-esp32-elf-llvm11_0_0-llvmorg-11-init-21249-g36dbc8b-linux-amd64.tar.xz
-tar xf xtensa-esp32-elf-llvm11_0_0-llvmorg-11-init-21249-g36dbc8b-linux-amd64.tar.xz
+wget https://github.com/espressif/llvm-project/releases/download/esp-12.0.1-20210823/xtensa-esp32-elf-llvm12_0_1-esp-12.0.1-20210823-linux-amd64.tar.xz
+tar xf xtensa-esp32-elf-llvm12_0_1-esp-12.0.1-20210823-linux-amd64.tar.xz
 export PATH="`pwd`/xtensa-esp32-elf-clang/bin/:$PATH"
 
 wget --continue https://github.com/espressif/rust-esp32-example/archive/refs/heads/main.zip


### PR DESCRIPTION
Updated LLVM installation instructions with the use of LLVM artifacts from GitHub. #25 
@georgik PTAL
