### PR TITLE
Docs: Use curl instead on wget on macOS

### DIFF
--- a/docs/rust-on-xtensa-installation-aarch64-apple-darwin.md
+++ b/docs/rust-on-xtensa-installation-aarch64-apple-darwin.md
@@ -23,21 +23,21 @@ TOOLCHAIN_DESTINATION_DIR="~/.rustup/toolchains/esp"
 
 mkdir -p ${TOOLCHAIN_DESTINATION_DIR}
 
-wget "https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/${RUST_DIST}.tar.xz"
+curl "https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/${RUST_DIST}.tar.xz" -o "${RUST_DIST}.tar.xz"
 tar xvf ${RUST_DIST}.tar.xz
 ./${RUST_DIST}/install.sh --destdir=${TOOLCHAIN_DESTINATION_DIR} --prefix="" --without=rust-docs
 
-wget "https://dl.espressif.com/dl/idf-rust/dist/noarch/${RUST_SRC_DIST}.tar.xz"
+curl "https://dl.espressif.com/dl/idf-rust/dist/noarch/${RUST_SRC_DIST}.tar.xz" -o "${RUST_SRC_DIST}.tar.xz"
 tar xvf ${RUST_SRC_DIST}.tar.xz
 ./${RUST_SRC_DIST}/install.sh --destdir=${TOOLCHAIN_DESTINATION_DIR} --prefix="" --without=rust-docs
 
 rustup default esp
 
-wget --continue "https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/xtensa-esp32-elf-llvm11_0_0-aarch64-apple-darwin.tar.xz"
+curl "https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/xtensa-esp32-elf-llvm11_0_0-aarch64-apple-darwin.tar.xz" -o "xtensa-esp32-elf-llvm11_0_0-aarch64-apple-darwin.tar.xz"
 tar xf xtensa-esp32-elf-llvm11_0_0-aarch64-apple-darwin.tar.xz
 export PATH="`pwd`/xtensa-esp32-elf-clang/bin/:$PATH"
 
-wget --continue https://github.com/espressif/rust-esp32-example/archive/refs/heads/main.zip
+curl -L https://github.com/espressif/rust-esp32-example/archive/refs/heads/main.zip -o main.zip
 unzip main.zip
 cd rust-esp32-example-main
 ```

--- a/docs/rust-on-xtensa-installation-aarch64-apple-darwin.md
+++ b/docs/rust-on-xtensa-installation-aarch64-apple-darwin.md
@@ -23,21 +23,21 @@ TOOLCHAIN_DESTINATION_DIR="~/.rustup/toolchains/esp"
 
 mkdir -p ${TOOLCHAIN_DESTINATION_DIR}
 
-curl "https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/${RUST_DIST}.tar.xz" -o "${RUST_DIST}.tar.xz"
+curl -O "https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/${RUST_DIST}.tar.xz"
 tar xvf ${RUST_DIST}.tar.xz
 ./${RUST_DIST}/install.sh --destdir=${TOOLCHAIN_DESTINATION_DIR} --prefix="" --without=rust-docs
 
-curl "https://dl.espressif.com/dl/idf-rust/dist/noarch/${RUST_SRC_DIST}.tar.xz" -o "${RUST_SRC_DIST}.tar.xz"
+curl -O "https://dl.espressif.com/dl/idf-rust/dist/noarch/${RUST_SRC_DIST}.tar.xz"
 tar xvf ${RUST_SRC_DIST}.tar.xz
 ./${RUST_SRC_DIST}/install.sh --destdir=${TOOLCHAIN_DESTINATION_DIR} --prefix="" --without=rust-docs
 
 rustup default esp
 
-curl "https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/xtensa-esp32-elf-llvm11_0_0-aarch64-apple-darwin.tar.xz" -o "xtensa-esp32-elf-llvm11_0_0-aarch64-apple-darwin.tar.xz"
+curl -O "https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/xtensa-esp32-elf-llvm11_0_0-aarch64-apple-darwin.tar.xz"
 tar xf xtensa-esp32-elf-llvm11_0_0-aarch64-apple-darwin.tar.xz
 export PATH="`pwd`/xtensa-esp32-elf-clang/bin/:$PATH"
 
-curl -L https://github.com/espressif/rust-esp32-example/archive/refs/heads/main.zip -o main.zip
+curl -LO "https://github.com/espressif/rust-esp32-example/archive/refs/heads/main.zip"
 unzip main.zip
 cd rust-esp32-example-main
 ```

--- a/docs/rust-on-xtensa-installation-x86_64-apple-darwin.md
+++ b/docs/rust-on-xtensa-installation-x86_64-apple-darwin.md
@@ -5,6 +5,7 @@ Following instructions are specific for ESP32 and ESP32-S series based on Xtensa
 Instructions for ESP-C series based on RISC-V architecture are described in document for [ESP32-C3](../README.md#esp32-c3).
 
 Tested OS: macOS Big Sur x64
+
 ## Prerequisites
 
 - rustup - installed with nightly toolchain - https://rustup.rs/
@@ -22,21 +23,21 @@ TOOLCHAIN_DESTINATION_DIR="~/.rustup/toolchains/esp"
 
 mkdir -p ${TOOLCHAIN_DESTINATION_DIR}
 
-wget "https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/${RUST_DIST}.tar.xz"
+curl "https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/${RUST_DIST}.tar.xz" -o "${RUST_DIST}.tar.xz"
 tar xvf ${RUST_DIST}.tar.xz
 ./${RUST_DIST}/install.sh --destdir=${TOOLCHAIN_DESTINATION_DIR} --prefix="" --without=rust-docs
 
-wget "https://dl.espressif.com/dl/idf-rust/dist/noarch/${RUST_SRC_DIST}.tar.xz"
+curl "https://dl.espressif.com/dl/idf-rust/dist/noarch/${RUST_SRC_DIST}.tar.xz" -o "${RUST_SRC_DIST}.tar.xz"
 tar xvf ${RUST_SRC_DIST}.tar.xz
 ./${RUST_SRC_DIST}/install.sh --destdir=${TOOLCHAIN_DESTINATION_DIR} --prefix="" --without=rust-docs
 
 rustup default esp
 
-wget "https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/xtensa-esp32-elf-llvm11_0_0-x86_64-apple-darwin.tar.xz"
+curl "https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/xtensa-esp32-elf-llvm11_0_0-x86_64-apple-darwin.tar.xz" -o "xtensa-esp32-elf-llvm11_0_0-x86_64-apple-darwin.tar.xz"
 tar xf xtensa-esp32-elf-llvm11_0_0-x86_64-apple-darwin.tar.xz
 export PATH="`pwd`/xtensa-esp32-elf-clang/bin/:$PATH"
 
-wget --continue https://github.com/espressif/rust-esp32-example/archive/refs/heads/main.zip
+curl -L "https://github.com/espressif/rust-esp32-example/archive/refs/heads/main.zip" -o main.zip
 unzip main.zip
 cd rust-esp32-example-main
 ```

--- a/docs/rust-on-xtensa-installation-x86_64-apple-darwin.md
+++ b/docs/rust-on-xtensa-installation-x86_64-apple-darwin.md
@@ -23,21 +23,21 @@ TOOLCHAIN_DESTINATION_DIR="~/.rustup/toolchains/esp"
 
 mkdir -p ${TOOLCHAIN_DESTINATION_DIR}
 
-curl "https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/${RUST_DIST}.tar.xz" -o "${RUST_DIST}.tar.xz"
+curl -O "https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/${RUST_DIST}.tar.xz"
 tar xvf ${RUST_DIST}.tar.xz
 ./${RUST_DIST}/install.sh --destdir=${TOOLCHAIN_DESTINATION_DIR} --prefix="" --without=rust-docs
 
-curl "https://dl.espressif.com/dl/idf-rust/dist/noarch/${RUST_SRC_DIST}.tar.xz" -o "${RUST_SRC_DIST}.tar.xz"
+curl -O "https://dl.espressif.com/dl/idf-rust/dist/noarch/${RUST_SRC_DIST}.tar.xz"
 tar xvf ${RUST_SRC_DIST}.tar.xz
 ./${RUST_SRC_DIST}/install.sh --destdir=${TOOLCHAIN_DESTINATION_DIR} --prefix="" --without=rust-docs
 
 rustup default esp
 
-curl "https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/xtensa-esp32-elf-llvm11_0_0-x86_64-apple-darwin.tar.xz" -o "xtensa-esp32-elf-llvm11_0_0-x86_64-apple-darwin.tar.xz"
+curl -O "https://dl.espressif.com/dl/idf-rust/dist/${ARCH}/xtensa-esp32-elf-llvm11_0_0-x86_64-apple-darwin.tar.xz"
 tar xf xtensa-esp32-elf-llvm11_0_0-x86_64-apple-darwin.tar.xz
 export PATH="`pwd`/xtensa-esp32-elf-clang/bin/:$PATH"
 
-curl -L "https://github.com/espressif/rust-esp32-example/archive/refs/heads/main.zip" -o main.zip
+curl -LO "https://github.com/espressif/rust-esp32-example/archive/refs/heads/main.zip"
 unzip main.zip
 cd rust-esp32-example-main
 ```


### PR DESCRIPTION
As `wget` is not bundled with the macOS, use `curl` to avoid installing additional dependencies.