### PR TITLE
Add missing header file for IDF 5.0

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -12,6 +12,10 @@
 #include "freertos/task.h"
 #include "esp_system.h"
 #include "esp_spi_flash.h"
+#include "esp_idf_version.h"
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
+#include "esp_chip_info.h"
+#endif
 
 #include "RustApi.h"
 


### PR DESCRIPTION
In IDF v4.3 and older, `esp_system.h` used to include `esp_chip_info` related functions.
In IDF v4.4, these functions were moved into a new header file, `esp_chip_info.h`. For compatibility, `esp_system.h` included `esp_chip_info.h`.
This compatibility include has been removed in IDF 5.0, so now we need to include `esp_chip_info.h` explicitly.

This PR adds a version check before including this header.

Should fix https://github.com/espressif/rust-esp32-example/issues/46.